### PR TITLE
Loose sig restrictions

### DIFF
--- a/afb/__init__.py
+++ b/afb/__init__.py
@@ -18,7 +18,7 @@ from __future__ import print_function
 
 from afb.core.manufacturer import Manufacturer
 from afb.core.broker import Broker
-from afb.core.specs import ParameterSpec
+from afb.core.specs import ArgumentSpec
 from afb.utils import create_mfr
 
 del absolute_import

--- a/afb/__init__.py
+++ b/afb/__init__.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 
 from afb.core.manufacturer import Manufacturer
 from afb.core.broker import Broker
+from afb.core.specs import ParameterSpec
 from afb.utils import create_mfr
 
 del absolute_import

--- a/afb/core/__init__.py
+++ b/afb/core/__init__.py
@@ -18,7 +18,7 @@ from __future__ import print_function
 
 from afb.core.broker import Broker
 from afb.core.manufacturer import Manufacturer
-from afb.core.specs import ParameterSpec
+from afb.core.specs import ArgumentSpec
 
 del absolute_import
 del division

--- a/afb/core/__init__.py
+++ b/afb/core/__init__.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 
 from afb.core.broker import Broker
 from afb.core.manufacturer import Manufacturer
+from afb.core.specs import ParameterSpec
 
 del absolute_import
 del division

--- a/afb/core/broker.py
+++ b/afb/core/broker.py
@@ -17,7 +17,6 @@ from __future__ import division
 from __future__ import print_function
 
 import os
-import six
 from threading import Lock
 
 from afb.core.manufacturer import Manufacturer
@@ -146,7 +145,7 @@ class Broker(object):
         `Manufacturer`s, or zero-argument functions where each returns one,
          to be merged. The key will be used across the iterable.
     """
-    for key, mfrs in six.iteritems(mfrs_dict):
+    for key, mfrs in mfrs_dict.items():
       for mfr in mfrs:
         self.merge_mfr(key, mfr)
 
@@ -205,7 +204,7 @@ class Broker(object):
                       "factory to its arguments for instantiation).\n"
                       "Target Type: {}\nGiven: {}".format(cls, spec))
 
-    method, params = next(six.iteritems(spec))
+    method, params = next(iter(spec.items()))
     if cls is dict and not mfr.has_method(method):
       return spec
     return mfr.make(method=method, params=params)

--- a/afb/core/broker.py
+++ b/afb/core/broker.py
@@ -17,7 +17,7 @@ from __future__ import division
 from __future__ import print_function
 
 import os
-from threading import Lock
+from threading import RLock
 
 from afb.core.manufacturer import Manufacturer
 from afb.core.primitives import make_primitive_mfrs
@@ -52,7 +52,7 @@ class Broker(object):
   """
 
   def __init__(self):
-    self._lock = Lock()
+    self._lock = RLock()
 
     # Initialize broker
     self._manufacturers = {}
@@ -68,6 +68,14 @@ class Broker(object):
 
   def get_manufacturer(self, cls):
     return self._manufacturers.get(cls)
+
+  def get_or_create(self, cls):
+    """Get class manufacturer. Create and register if one does not exist."""
+    if cls not in self._manufacturers:
+      with self._lock:
+        if cls not in self._manufacturers:
+          self.register(Manufacturer(cls))
+    return self._manufacturers[cls]
 
   def add_factory(self,
                   cls,

--- a/afb/core/manufacturer.py
+++ b/afb/core/manufacturer.py
@@ -649,8 +649,8 @@ def _format_signature(f, sig):
         continue
 
       pspec = sig.pop(k)
-      if not isinstance(pspec, specs.ParameterSpec):
-        pspec = specs.ParameterSpec.from_raw_spec(pspec)
+      if not isinstance(pspec, specs.ArgumentSpec):
+        pspec = specs.ArgumentSpec.from_raw_spec(pspec)
 
       if p.default == inspect.Parameter.empty or pspec.forced:
         rqd_sig[k] = pspec.details
@@ -666,8 +666,8 @@ def _format_signature(f, sig):
     if not allow_implicit:
       raise errors.SignatureError("No such arguments: %s" % list(sig))
     for k, pspec in sig.items():
-      if not isinstance(pspec, specs.ParameterSpec):
-        pspec = specs.ParameterSpec.from_raw_spec(pspec)
+      if not isinstance(pspec, specs.ArgumentSpec):
+        pspec = specs.ArgumentSpec.from_raw_spec(pspec)
       [opt_sig, rqd_sig][pspec.forced][k] = pspec.details
 
   rqds = set(rqd_sig)

--- a/afb/core/manufacturer.py
+++ b/afb/core/manufacturer.py
@@ -633,7 +633,7 @@ def _format_signature(f, sig):
   rqd_sig = collections.OrderedDict()
   opt_sig = collections.OrderedDict()
   missing = []
-  allow_implicits = False
+  allow_implicit = False
 
   for k, p in fparams.items():
     if p.kind == inspect.Parameter.POSITIONAL_ONLY:
@@ -642,7 +642,7 @@ def _format_signature(f, sig):
       # TODO: Give warning that variate positionals will not be used.
       pass
     elif p.kind == inspect.Parameter.VAR_KEYWORD:
-      allow_implicits = True
+      allow_implicit = True
     else:
       if k not in sig:
         missing.append(k)
@@ -663,7 +663,7 @@ def _format_signature(f, sig):
   del missing
 
   if sig:
-    if not allow_implicits:
+    if not allow_implicit:
       raise errors.SignatureError("No such arguments: %s" % list(sig))
     for k, pspec in sig.items():
       if not isinstance(pspec, specs.ParameterSpec):
@@ -673,7 +673,6 @@ def _format_signature(f, sig):
   rqds = set(rqd_sig)
   indexed = collections.OrderedDict(rqd_sig)
   indexed.update(opt_sig)
-  print(indexed)
   return rqds, indexed
 
 

--- a/afb/core/manufacturer.py
+++ b/afb/core/manufacturer.py
@@ -20,12 +20,10 @@ import copy
 import functools
 import inspect
 import logging
-import os
 import sys
 import threading
 
-import six
-
+from afb.core import specs
 from afb.core import static
 from afb.utils import errors
 from afb.utils import keys
@@ -178,11 +176,15 @@ class Manufacturer(object):
   def _get_factory_spec(self, key):
     return self._static.get(key) or self._dynamic.get(key)
 
-  def merge(self, root, mfr):
+  def merge(self, root, mfr, force=False, sep="/"):
     """Merge another manufacturer of the same type.
 
     This method registers all the factories from the given Manufacturer.
     The resulting key of the merged factories will have the following form:
+
+      * "root<sep><method_name>"
+
+    For instance, using the default `sep="/"`, the factory key becomes:
 
       * "root/<method_name>"
 
@@ -194,6 +196,10 @@ class Manufacturer(object):
       root: A string that serves as the root of the factories from `mfr`.
         If empty, the original method name will be used directly.
       mfr: `Manufacturer` or a zero-argument function that returns one.
+      force: If True, overwrites the original factory registration in case of
+        key collision. Otherwise, an error is raised. Defaults to False.
+      sep: Separator between root and method name in the resulting factory key.
+        Defaults to "/".
 
     Raises:
       KeyError:
@@ -209,10 +215,10 @@ class Manufacturer(object):
                         "\"mfr\" must be either a `Manufacturer` or a "
                         "zero-argument function that returns one. "
                         "Given: {}".format(mfr))
-    self._validate_merge_request(root, mfr)
-    self._merge(root, mfr)
+    self._validate_merge_request(root, mfr, force=force, sep=sep)
+    self._merge(root, mfr, force=force, sep=sep)
 
-  def merge_all(self, mfr_dict, force=False):
+  def merge_all(self, mfr_dict, force=False, sep="/"):
     """Merges multiple manufacturers.
 
     Args:
@@ -220,6 +226,8 @@ class Manufacturer(object):
         functions where each returns a `Manufacturer`.
       force: If `True`, overwrites the existing factory (if any). If `False`,
         raises ValueError if `key` is already registered. Defaults to `False`.
+      sep: Separator between root and method name in the resulting factory key.
+        Defaults to "/". See `Manufacturer.merge` for details.
 
     Raises:
       KeyError:
@@ -230,21 +238,21 @@ class Manufacturer(object):
         - Output class of `mfr` is not a subclass of this output class.
     """
     mfr_dict_validated = {}
-    for root, mfr in six.iteritems(mfr_dict):
+    for root, mfr in mfr_dict.items():
       mfr = types.maybe_get_cls(mfr, Manufacturer)
       self._validate_merge_request(root, mfr, force=force)
       mfr_dict_validated[root] = mfr
 
-    for root, mfr in six.iteritems(mfr_dict_validated):
-      self._merge(root, mfr, force=force)
+    for root, mfr in mfr_dict_validated.items():
+      self._merge(root, mfr, force=force, sep=sep)
 
-  def _merge(self, root, mfr, force=False):
+  def _merge(self, root, mfr, force=False, sep="/"):
     factories = mfr.dynamic_factories
-    for key, spec in six.iteritems(factories):
-      key = _merged_name(root, key)
+    for key, spec in factories.items():
+      key = _merged_name(root, key, sep=sep)
       self.register(key=key,
                     factory=spec["fn"],
-                    sig=spec["sig"],
+                    signature=spec["sig"],
                     params=spec["params"],
                     descriptions=spec["descriptions"],
                     force=force)
@@ -256,21 +264,62 @@ class Manufacturer(object):
   def register(self,
                key,
                factory,
-               sig,
+               signature,
                params=None,
                descriptions=None,
                force=False):
     """Register a factory.
 
+    The `factory` is the callable to be used for object creation. The details of
+    each of the factory arguments needs to be specified in `signature`.
+
+    ----------------------------------------------------------------------------
+
+    Signature
+    =========
+
+    The required signature is a `dict` mapping in the following format:
+
+      {
+        <arg-name>: `ParameterSpec` (or its raw format) / Type Specification,
+        ...
+      }
+
+    The raw format of `ParameterSpec` is `dict` in the following format:
+
+      {
+        "type": Type Specification,
+        "description": (optional) "Description of the argument",
+        "forced": (optional) True / False (default)
+      }
+
+    The description will be rendered in the exported documentation.
+    The `forced` switch indicates whether the argument should be registered
+    as required. If `True`, the argument is required by when calling this
+    factory through `Manufacturer.make`. If `False`, its requirement will be
+    inferred from the factory's raw signature.
+
+    A type specification is either of the following:
+
+      - Singleton `dict` where the key and value are both type specifications;
+      - Singleton `list`, where the content is a type specification;
+      - `tuple` of type specifications; or
+      - A class or type.
+
+    For example, the type specification of a dict mapping a string to
+    `TestClass` objects would be `{str: TestClass}`.
+
+    ----------------------------------------------------------------------------
+
     Args:
       key: A string key that identifies the factory.
       factory: The factory to be registered.
-      sig: The signature of the input parameters. It is a dict mapping each
-        argument of factory to its expected type.
+      signature: The signature of the input parameters. It is a dict mapping
+        each argument of factory to its parameter specification.
       params: (Optional) Default parameters for this factory.
       descriptions: (Optional) Descriptions of this factory. If provided, it
-        must specifies the short description keyed by "short". A long
-        description keyed by "long" can optionally be included.
+        must a string or a dict with short description by "short" (required),
+        and a long description by "long" (optional).
       force: If `True`, overwrites the existing factory (if any). If `False`,
         raises ValueError if `key` is already registered. Defaults to `False`.
 
@@ -289,7 +338,7 @@ class Manufacturer(object):
     """
     self._register(key,
                    factory,
-                   sig,
+                   signature,
                    params=params,
                    descriptions=descriptions,
                    force=force)
@@ -307,7 +356,7 @@ class Manufacturer(object):
     Or a dictionary in keyword mode:
 
         {"factory": factory,            # required
-         "sig": signature,              # required
+         "signature": signature,        # required
          "params": default_params,      # optional
          "descriptions": descriptions}  # optional
 
@@ -370,23 +419,27 @@ class Manufacturer(object):
         * Keyword mode - A dictionary:
 
           {"factory": factory,            # required
-           "sig": signature,              # required
+           "signature": signature,        # required
            "params": default_params,      # optional
            "descriptions": descriptions}  # optional
 
       keyword_mode: Boolean. Indicates the mode in which to perform factory
         registrations. See above.
     """
-    for k, fn in six.iteritems(factories_fn_dict):
+    for k, fn in factories_fn_dict.items():
       if keyword_mode:
-        self.register(k, **fn())
+        kwargs = fn()
+        if "sig" in kwargs:
+          kwargs["signature"] = kwargs["sig"]
+          del kwargs["sig"]
+        self.register(k, **kwargs)
       else:
         self.register(k, *fn())
 
   def _register(self,
                 key,
                 factory,
-                sig,
+                signature,
                 params=None,
                 descriptions=None,
                 force=False,
@@ -406,14 +459,12 @@ class Manufacturer(object):
     self._wrap_error(
         lambda: errors.validate_is_callable(factory, "factory"), key=key)
 
-    if not isinstance(sig, dict):
-      raise self._raise_error(TypeError,
-                              "Method: {}\n`sig` must be a dict mapping "
-                              "factory arguments to their corresponding type "
-                              "specification or `dict` with type "
-                              "specification and description, keyed by "
-                              "\"type\" and \"description\" respectively."
-                              .format(key))  # TODO: Update this
+    if not isinstance(signature, dict):
+      raise self._raise_error(
+          TypeError,
+          "Method: {}\n`sig` must be a dict mapping factory arguments to their "
+          "parameter specification, or (deprecated) type specification."
+          .format(key))
 
     params = params or {}
     self._wrap_error(
@@ -426,7 +477,7 @@ class Manufacturer(object):
 
     # Normalize signature and determine required arguments.
     rqd_args, norm_sig = self._wrap_error(
-        lambda: _format_signature(factory, sig), key=key)
+        lambda: _format_signature(factory, signature), key=key)
 
     # Register factory.
     with self._lock:
@@ -489,14 +540,14 @@ class Manufacturer(object):
         lambda: errors.validate_rqd_args(params, rqd_args), key=method)
 
     # 2.2. Validate parameter structures
-    for k, p in six.iteritems(params):
+    for k, p in params.items():
       type_spec = sig[k]["type"]
       self._wrap_error(lambda: errors.validate_struct(type_spec, p),
                        prefix="Method: {}\nArgument: {}".format(method, k))
 
     # 2.3. Construct inputs
     inputs = {}
-    for k, p in six.iteritems(params):
+    for k, p in params.items():
       inputs[k] = None if p is None else self._get_struct(sig[k]["type"], p)
 
     # 3. Call factory
@@ -514,10 +565,10 @@ class Manufacturer(object):
       return [self._get_struct(t, n) for n in nested]
 
     if isinstance(type_spec, dict):
-      kt, vt = next(six.iteritems(type_spec))
+      kt, vt = next(iter(type_spec.items()))
       if isinstance(nested, dict):
         return {self._get_struct(kt, kn): self._get_struct(vt, vn)
-                for kn, vn in six.iteritems(nested)}
+                for kn, vn in nested.items()}
       elif isinstance(nested, (list, tuple)):
         return {self._get_struct(kt, kn): self._get_struct(vt, vn)
                 for kn, vn in nested}
@@ -532,7 +583,7 @@ class Manufacturer(object):
     # This line should be unreachable.
     raise errors.StructMismatchError()
 
-  def _validate_merge_request(self, key, mfr, force=False):
+  def _validate_merge_request(self, key, mfr, force=False, sep="/"):
     if not isinstance(key, str):
       raise self._raise_error(TypeError,
                               "`key` must be a `str`. Given: {}".format(key))
@@ -546,7 +597,7 @@ class Manufacturer(object):
                               "The output class of `mfr` must be a subclass of "
                               "{}, given: {}".format(self.cls, mfr.cls))
     factories = mfr.dynamic_factories
-    merged_names = set(_merged_name(key, n) for n in factories)
+    merged_names = set(_merged_name(key, n, sep=sep) for n in factories)
     collisions = merged_names.intersection(self._dynamic)
     if collisions:
       if force:
@@ -590,7 +641,7 @@ def _format_signature(f, sig):
   summary = {}
   for k, p in fparams.items(): summary.setdefault(p.kind, set()).add(k)
   if inspect.Parameter.POSITIONAL_ONLY in summary:
-    raise ValueError("...")  # Not supported
+    raise errors.SignatureError("Positional-only parameter is not supported.")
 
   if inspect.Parameter.VAR_POSITIONAL in summary:
     # TODO: Give warning that variant positionals will not be used.
@@ -600,29 +651,28 @@ def _format_signature(f, sig):
   fargs = functools.reduce(lambda l, r: l.union(r), summary.values(), set())
 
   rqd_args, norm_sig = set(), {}
+  invalid_args = set()
   for arg, param_or_spec in sig.items():
     if arg not in fargs and not has_varkw:
-      raise KeyError("")  # No such argument
-    param = _normalize_param(param_or_spec)
-    norm_sig[arg] = param
-    if arg in frqd or param.pop("forced", False):
+      invalid_args.add(arg)
+    if invalid_args: continue
+
+    param = param_or_spec
+    if not isinstance(param, specs.ParameterSpec):
+      param = specs.ParameterSpec.from_raw_spec(param)
+
+    norm_sig[arg] = param.details
+    if arg in frqd or param.forced:
       rqd_args.add(arg)
+
+  if invalid_args:
+    raise errors.SignatureError("No such arguments: %s" % sorted(invalid_args))
 
   return rqd_args, norm_sig
 
 
-def _normalize_param(param_or_spec):
-  param = param_or_spec
-  if not _is_param_format(param):
-    param = {"type": param, "description": ""}
-  errors.validate_type_spec(param["type"])
-
-  return param
-
-
-def _merged_name(root, name):
-  root = root or ""
-  return os.path.join(root, name).replace("\\", "/")
+def _merged_name(root, name, sep="/"):
+  return "%s%s%s" % (root, sep, name) if root else name
 
 
 def _is_param_format(spec):
@@ -642,11 +692,9 @@ def _normalized_factory_descriptions(desc, method):
   if (not isinstance(desc, dict)) or \
      ("short" not in desc) or \
      (set(desc) - valid_keys):
-    # TODO: Update this
-    raise ValueError("The factory description must either be `None` or a `dict`"
-                     " with the short description keyed as by \"short\" "
-                     "included. A long description keyed by \"long\" can be "
-                     "optionally provided.\n"
+    raise ValueError("The factory description must either be `None`, a `str`,"
+                     "or a `dict` including short description as \"short\" "
+                     "(required) and long description as \"long\" (optional)."
                      "Method: {}\nGiven: {}".format(method, desc))
   short = desc["short"]
   long = desc.get("long", "")

--- a/afb/core/manufacturer.py
+++ b/afb/core/manufacturer.py
@@ -597,7 +597,7 @@ def _format_signature(f, sig):
     del summary[inspect.Parameter.VAR_POSITIONAL]
 
   has_varkw = len(summary.pop(inspect.Parameter.VAR_KEYWORD, "")) > 0
-  fargs = functools.reduce(lambda l, r: l.union(r), fparams.values(), set())
+  fargs = functools.reduce(lambda l, r: l.union(r), summary.values(), set())
 
   rqd_args, norm_sig = set(), {}
   for arg, param_or_spec in sig.items():

--- a/afb/core/primitives/factories/dict_lib/config.py
+++ b/afb/core/primitives/factories/dict_lib/config.py
@@ -18,7 +18,7 @@ CONFIG_LOADER = {
 
 def get_load_config():
   sig = {
-      "config": specs.ParameterSpec(
+      "config": specs.ArgumentSpec(
           str,
           description="Path to configuration file containing a "
                       "representation corresponding to a single `dict`."),

--- a/afb/core/primitives/factories/dict_lib/config.py
+++ b/afb/core/primitives/factories/dict_lib/config.py
@@ -6,41 +6,40 @@ import yaml
 import json
 import os
 
+from afb.core import specs
+
+
 CONFIG_LOADER = {
-    'yaml': yaml.load,
-    'yml': yaml.load,
+    'yaml': yaml.safe_load,
+    'yml': yaml.safe_load,
     'json': json.load,
 }
 
 
 def get_load_config():
-  descriptions = {
-      "short": "Loads dictionary from config file.",
-      "long":
-          """The currently supported file format is YAML and JSON.
-          
-          The file format is determined by the file extension:
-          
-          - YAML: `.yaml`, `.yml`
-          - JSON: `.json`
-          
-          The config file must contain a representation that will be
-          deserialized into a single `dict`.
-          """,
-  }
-
   sig = {
-      "config": {
-          "type": str,
-          "description": "Path to configuration file containing a "
-                         "representation corresponding to a single `dict`.",
-      },
+      "config": specs.ParameterSpec(
+          str,
+          description="Path to configuration file containing a "
+                      "representation corresponding to a single `dict`."),
   }
 
-  return {"factory": load_config, "sig": sig, "descriptions": descriptions}
+  return {"factory": load_config, "signature": sig}
 
 
 def load_config(config):
+  """Loads dictionary from config file.
+
+  The currently supported file format is YAML and JSON.
+
+  The file format is determined by the file extension:
+
+  - YAML: `.yaml`, `.yml`
+  - JSON: `.json`
+
+  The config file must contain a representation that will be deserialized into
+  a single `dict`. Additional dictionaries (e.g. from YAML) are ignored.
+  """
   format = os.path.splitext(config)[1][1:].lower()
   with open(config, 'rb') as f:
     data = CONFIG_LOADER[format](f)

--- a/afb/core/primitives/primitive_mfrs.py
+++ b/afb/core/primitives/primitive_mfrs.py
@@ -16,8 +16,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import six
-
 from afb.core.primitives.factories import dict_lib
 from afb.utils import misc
 
@@ -37,4 +35,4 @@ _STATIC_FACTORIES = {
 
 def make_primitive_mfrs():
   return [misc.create_mfr_with_static_factories(cls, cls_reg, keyword_mode=True)
-          for cls, cls_reg in six.iteritems(_STATIC_FACTORIES)]
+          for cls, cls_reg in _STATIC_FACTORIES.items()]

--- a/afb/core/specs.py
+++ b/afb/core/specs.py
@@ -1,0 +1,35 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from afb.utils import errors
+
+
+class ParameterSpec(object):
+  def __init__(self, type, description="", forced=False):
+    errors.validate_type_spec(type)
+    self._tspec = type
+    self._description = description
+    self._forced = forced
+
+  @property
+  def forced(self):
+    return self._forced
+
+  @property
+  def details(self):
+    return {"type": self._tspec, "description": self._description}
+
+  @classmethod
+  def from_raw_spec(cls, param_or_type_spec):
+    param = param_or_type_spec
+    if not _is_param_format(param):
+      param = {"type": param}
+    return cls(**param)
+
+
+def _is_param_format(spec):
+  if isinstance(spec, dict):
+    unknown_keys = set(spec) - {"type", "description", "forced"}
+    return "type" in spec and not unknown_keys
+  return False

--- a/afb/core/specs.py
+++ b/afb/core/specs.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 from afb.utils import errors
 
 
-class ParameterSpec(object):
+class ArgumentSpec(object):
   def __init__(self, type, description="", forced=False):
     errors.validate_type_spec(type)
     self._tspec = type

--- a/afb/core/static/from_config.py
+++ b/afb/core/static/from_config.py
@@ -16,37 +16,34 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from afb.core import specs
+
 
 def make_from_config(mfr):
-  descriptions = {
-      "short": "Constructs object from object specification in config file.",
-      "long":
-          """This function constructs the object from object specification
-          contained in a config file.
-    
-          Current, only YAML and JSON is supported. The format is determined
-          by the file extension, where
-    
-          - `.yaml`, `yml` -> YAML
-          - `.json` -> JSON
-    
-          The config file must contain exactly one object specification. That
-          is, it must contain a singleton dictionary that maps a factory name
-          to its parameters.
-          """,
-  }
-
   sig = {
-      "config": {
-          "type": str,
-          "description": 'Config file in YAML/JSON, containing a single '
-                         'object specification for class "{}"'
-                         .format(mfr.cls.__name__),
-      },
+      "config": specs.ParameterSpec(
+          str,
+          description="Config file in YAML/JSON, containing a single "
+                      'object specification for class "%s"' % mfr.cls.__name__),
   }
 
   def from_config(config):
+    """Constructs object from object specification in config file.
+
+    This function constructs the object from object specification contained
+    in a config file.
+
+    Current, only YAML and JSON is supported. The format is determined by the
+    file extension, where
+
+    - `.yaml`, `yml` -> YAML
+    - `.json` -> JSON
+
+    The config file must contain exactly one object specification. That is, it
+    must contain a singleton dictionary that maps a factory name to its
+    parameters.
+    """
     params = mfr._broker.make(dict, {"load_config": {"config": config}})  # pylint: disable=protected-access
     return mfr._broker.make(mfr.cls, params)  # pylint: disable=protected-access
 
-  return {"factory": from_config, "sig": sig, "descriptions": descriptions}
+  return {"factory": from_config, "signature": sig}

--- a/afb/core/static/from_config.py
+++ b/afb/core/static/from_config.py
@@ -21,7 +21,7 @@ from afb.core import specs
 
 def make_from_config(mfr):
   sig = {
-      "config": specs.ParameterSpec(
+      "config": specs.ArgumentSpec(
           str,
           description="Config file in YAML/JSON, containing a single "
                       'object specification for class "%s"' % mfr.cls.__name__),

--- a/afb/core/static/registry.py
+++ b/afb/core/static/registry.py
@@ -18,8 +18,6 @@ from __future__ import print_function
 
 from afb.core.static import from_config
 
-import six
-
 
 _STATIC_FACTORIES = {
     "from_config": from_config.make_from_config,
@@ -28,6 +26,6 @@ _STATIC_FACTORIES = {
 
 def make_static_factories(mfr):
   regs = []
-  for key, make_fct in six.iteritems(_STATIC_FACTORIES):
+  for key, make_fct in _STATIC_FACTORIES.items():
     regs.append(dict(key=key, **make_fct(mfr)))
   return regs

--- a/afb/ext/app/_registry.py
+++ b/afb/ext/app/_registry.py
@@ -16,8 +16,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import six
-
 from afb.core import broker as brk_lib
 from afb.ext.app import job
 from afb.ext.app import task
@@ -46,7 +44,7 @@ _REGISTRY = {
 
 def make_broker():
   broker = brk_lib.Broker()
-  for cls, cls_reg in six.iteritems(_REGISTRY):
+  for cls, cls_reg in _REGISTRY.items():
     [broker.add_factory(cls, k, **get_fct())
-     for k, get_fct in six.iteritems(cls_reg)]
+     for k, get_fct in cls_reg.items()]
   return broker

--- a/afb/ext/app/values/algebra.py
+++ b/afb/ext/app/values/algebra.py
@@ -19,8 +19,6 @@ from __future__ import print_function
 import copy
 import itertools
 
-import six
-
 from afb.ext.app.values import values as val_base
 
 
@@ -122,7 +120,7 @@ class _ComposedDictValues(val_base.Values):
     self._base = base or {}
 
   def _make_iterator(self):
-    keys, vals = list(zip(*list(six.iteritems(self._values_map.items))))
+    keys, vals = list(zip(*list(self._values_map.items.items())))
     its = [v.make_iterator() for v in vals]
 
     for comb in self._combine_fn(*its):

--- a/afb/utils/docs.py
+++ b/afb/utils/docs.py
@@ -86,28 +86,23 @@ def export_factories_markdown(mfr,
     depth = len(factory_doc_path_rel.split('/')) - 1
     doc_root_rel = '/'.join([".."] * depth)
 
-    def format_arg_list_entry(arg, arg_sig, optional):
-      arg_line = "- %s`%s`:" % ("(optional) " if optional else "", arg)
-      type_spec = arg_sig["type"]
+    def format_arg_list_entry(name, arg, optional):
+      arg_line = "- %s`%s`:" % ("(optional) " if optional else "", name)
+      type_spec = arg["type"]
       type_line = make_type_line(
           type_spec, doc_root_rel, cls_dir_fn, cls_desc_name, full_type=False)
       full_type_line = make_type_line(
           type_spec, doc_root_rel, cls_dir_fn, cls_desc_name, full_type=True)
 
-      desc_line = "  - Description: %s" % arg_sig["description"]
+      desc_line = "  - Description: %s" % arg["description"]
       return "\n".join((arg_line, type_line, full_type_line, desc_line))
 
-    fn = entry["fn"]
     sig = entry["sig"]
     rqd_args = entry["rqd_args"]
-    parameters = inspect.signature(fn).parameters
     arg_doc_list = []
-    for p in parameters:
-      if p not in sig:
-        continue
-      arg_sig = sig[p]
-      optional = p not in rqd_args
-      arg_doc_list.append(format_arg_list_entry(p, arg_sig, optional))
+    for k, p in sig.items():
+      optional = k not in rqd_args
+      arg_doc_list.append(format_arg_list_entry(k, p, optional))
 
     signature_doc = "## Arguments\n\n%s" % "\n".join(arg_doc_list)
     factory_doc = "\n\n".join((title, description, signature_doc))

--- a/afb/utils/docs.py
+++ b/afb/utils/docs.py
@@ -18,7 +18,6 @@ from __future__ import print_function
 
 import inspect
 import os
-import six
 
 
 def export_class_markdown(mfr,
@@ -45,13 +44,13 @@ def export_class_markdown(mfr,
   description = "## Description\n\n%s" % cls_doc
   format_factory_list_entry = create_format_list_entry_fn(factory_doc_path_fn)
   factory_doc_list = ["  - %s" % format_factory_list_entry(k, d)
-                      for k, d in sorted(six.iteritems(dynamic_fcts))]
+                      for k, d in sorted(dynamic_fcts.items())]
   factory_doc_list_str = "\n".join(factory_doc_list)
   factories_doc = "## Factories\n\n%s\n" % factory_doc_list_str
 
   format_static_list_entry = create_format_list_entry_fn(static_doc_path_fn)
   statics_doc_list = ["  - %s" % format_static_list_entry(k, d)
-                       for k, d in sorted(six.iteritems(static_fcts))]
+                      for k, d in sorted(static_fcts.items())]
   statics_doc_list_str = "\n".join(statics_doc_list)
   statics_doc = "## Static\n\n%s\n" % statics_doc_list_str
 
@@ -74,7 +73,7 @@ def export_factories_markdown(mfr,
   cls_name = cls.__qualname__
   factories = mfr.static_factories if static else mfr.dynamic_factories
 
-  for k, entry in six.iteritems(factories):
+  for k, entry in factories.items():
     title = "# %s - `%s`" % (cls_name, k)
 
     short = inspect.cleandoc(entry["descriptions"]["short"])
@@ -137,7 +136,7 @@ def get_type_spec_repr(type_spec, link_fn):
   if isinstance(type_spec, list):
     return "[%s]" % get_type_spec_repr(type_spec[0], link_fn)
   if isinstance(type_spec, dict):
-    kt, vt = next(six.iteritems(type_spec))
+    kt, vt = next(iter(type_spec.items()))
     return "{%s: %s}" % (get_type_spec_repr(kt, link_fn),
                          get_type_spec_repr(vt, link_fn))
   if isinstance(type_spec, tuple):

--- a/afb/utils/errors.py
+++ b/afb/utils/errors.py
@@ -16,8 +16,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import six
-
 from afb.utils import types
 
 
@@ -25,8 +23,12 @@ class StructMismatchError(Exception):
   pass
 
 
+class SignatureError(Exception):
+  pass
+
+
 def validate_is_callable(obj, name):
-  if not six.callable(obj):
+  if not callable(obj):
     raise ValueError("`{}` must be a callable. Given: {}".format(name, obj))
 
 
@@ -55,7 +57,7 @@ def validate_rqd_args(input_args, rqd_args):
                             sorted(input_args),
                             sorted(missing)))
 
-  inv_args = {k for k, v in six.iteritems(input_args)
+  inv_args = {k for k, v in input_args.items()
               if k in rqd_args and v is None}
   if inv_args:
     raise ValueError("Required arguments must not be None.\n"
@@ -73,7 +75,7 @@ def validate_kwargs(obj, name):
                     "Given {}".format(name, type(obj)))
   inv_keys = []
   for k in obj:
-    if not isinstance(k, six.string_types):
+    if not isinstance(k, str):
       inv_keys.append(k)
   if inv_keys:
     raise TypeError("Keys in `{}` must be of string type. Given: {}"
@@ -89,9 +91,9 @@ def validate_struct(type_spec, struct):
 
   # `dict` case
   if isinstance(type_spec, dict):
-    k_spec, v_spec = next(six.iteritems(type_spec))
+    k_spec, v_spec = next(iter(type_spec.items()))
     if isinstance(struct, dict):
-      for ks, vs in six.iteritems(struct):
+      for ks, vs in struct.items():
         validate_struct(k_spec, ks)
         validate_struct(v_spec, vs)
       return
@@ -144,7 +146,7 @@ def validate_type_spec(type_spec):
     validate_type_spec(type_spec[0])
     return
   if isinstance(type_spec, dict) and len(type_spec) == 1:
-    k, v = next(six.iteritems(type_spec))
+    k, v = next(iter(type_spec.items()))
     validate_type_spec(k)
     validate_type_spec(v)
     return

--- a/afb/utils/misc.py
+++ b/afb/utils/misc.py
@@ -16,8 +16,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import six
-
 from afb.core import manufacturer as mfr_lib
 from afb.utils import keys
 
@@ -32,7 +30,7 @@ def create_mfr_with_static_factories(cls, fct_fn_dict, keyword_mode=False):
   class StaticManufacturer(mfr_lib.Manufacturer):
     def _init_static(self):
       super(StaticManufacturer, self)._init_static()
-      for k, fn in six.iteritems(fct_fn_dict):
+      for k, fn in fct_fn_dict.items():
         if keyword_mode:
           kwargs = dict(fn(), factory_type=keys.FactoryType.STATIC)
           self._register(k, **kwargs)

--- a/afb/utils/specs.py
+++ b/afb/utils/specs.py
@@ -16,8 +16,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import six
-
 from afb.utils import errors
 
 
@@ -26,7 +24,7 @@ def type_spec_repr(type_spec):
   if isinstance(type_spec, list):
     return "[{}]".format(type_spec_repr(type_spec[0]))
   elif isinstance(type_spec, dict):
-    k, v = next(six.iteritems(type_spec))
+    k, v = next(iter(type_spec.items()))
     return "{%s: %s}" % (type_spec_repr(k), type_spec_repr(v))
   elif isinstance(type_spec, tuple):
     return "({})".format(", ".join(type_spec))

--- a/afb/utils/types.py
+++ b/afb/utils/types.py
@@ -17,14 +17,13 @@ from __future__ import division
 from __future__ import print_function
 
 import inspect
-import six
 
 
 def maybe_get_cls(maybe_obj, cls):
   obj = None
   if isinstance(maybe_obj, cls):
     obj = maybe_obj
-  elif (six.callable(maybe_obj) and
+  elif (callable(maybe_obj) and
         len(inspect.signature(maybe_obj).parameters) == 0):
     obj = maybe_obj()
 
@@ -37,7 +36,7 @@ def maybe_get_cls(maybe_obj, cls):
 
 def is_obj_spec(x):
   if isinstance(x, dict) and len(x) == 1:
-    k, v = next(six.iteritems(x))
+    k, v = next(iter(x.items()))
     return isinstance(k, str) and isinstance(v, dict)
   return False
 
@@ -46,7 +45,7 @@ def is_type_spec(t):
   if isinstance(t, list) and len(t) == 1:
     return is_type_spec(t[0])
   if isinstance(t, dict) and len(t) == 1:
-    k, v = next(six.iteritems(t))
+    k, v = next(iter(t.items()))
     return is_type_spec(k) and is_type_spec(v)
   if isinstance(t, tuple):
     return all(is_type_spec(s) for s in t)

--- a/test/_registry.py
+++ b/test/_registry.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import six
-
 import afb
 
 from test import tasks
@@ -30,6 +28,6 @@ _REGISTRY = {
 
 def make_broker():
   broker = afb.Broker()
-  for cls, reg in six.iteritems(_REGISTRY):
-    [broker.add_factory(cls, k, **fn()) for k, fn in six.iteritems(reg)]
+  for cls, reg in _REGISTRY.items():
+    [broker.add_factory(cls, k, **fn()) for k, fn in reg.items()]
   return broker


### PR DESCRIPTION
# Loose signature restrictions

## Problem

The current version restricts factories to have explicit arguments, it has no support for implicit arguments. For example

```python
# Explicit arguments
def f(a, b=1):
  pass

# Implicit arguments
def g(a, **kwargs):
  pass
```

While `f` can be registered to a `Manufacturer` using a signature with both `a` and `b` as arguments, the function `g` cannot.

## Analysis

The reason is that the current code takes the names from the function's raw signature directly to match with the user-provided signature for registration. Therefore, the library sees `kwargs` as a single argument, rather then an indication of existence of unspecified ones.

## Solution

This PR loosens this restriction by modifying the parsing and index logic of factories. The factory's raw signature is first inspected, and categorized according to their kinds:

- POSITIONAL_ONLY: Not supported, as factories are invoked with unpacked dictionaries. A `SignatureError` will be raised if one is encountered
- POSITIONAL_OR_KEYWORD: Supported, just as before
- KEYWORD_ONLY: Supported, just as before
- VAR_POSITIONAL: Not supported. Instead of an error, a warning should be given to indicate that it is not used
- VAR_KEYWORD: Supported. The name used for variate keyword argument in the raw signature is not used. Instead, it indicates that the factory may accept arguments in the user-specified signature that are not present explicitly in the raw one.

This allows the `**kwargs` to be used to indicate acceptance of implicit arguments.

The order of arguments listed in the exported documentation was previously determined by the order of arguments in the raw signature. However, the raw signature no longer contains the full set of accepted arguments. How should the order by determined? The following ordering scheme is proposed:

1. Required explicit argument
2. Required implicit argument
3. Optional explicit argument
4. Optional implicit argument

**Explanation**

1. An argument is explicit if it is present in the raw signature, otherwise it is implicit.
2. An argument is required if it is a positional argument or marked `forced=True` in its argument specifiction.

Other than the original `type` and `description` items in the argument specification, this PR proposes an optional `forced` item (defaults to `False`) which forces the argument to be treated as required. Otherwise, its requiredness will be inferred (explicit positional -> required, otherwise optional).

This PR also comes with several modifications, namely:

- Added `Broker.get` to replace `Broker.get_manufacturer`, the latter is marked deprecated.
- Added `create_mfr` switch to `Broker.add_factory`
- Added `Broker.get_or_create` to get `Manufacturer`, and create one if not exists

